### PR TITLE
Changing timestamp format to ISO8601 with timezone

### DIFF
--- a/src/typescript-loggable.ts
+++ b/src/typescript-loggable.ts
@@ -121,7 +121,7 @@ export class Logger {
         const options: Winston.LoggerOptions = Logger.mainLoggerConfig.loggerOptions || {
             format: Winston.format.combine(
                 Winston.format.timestamp({
-                    format: 'YYYY-MM-DD HH:mm:ss'
+                    format: 'YYYY-MM-DDTHH:mm:ss.SSSZZ'
                 }),
                 Winston.format.ms(),
                 (Logger.mainLoggerConfig.format ? Winston.format.printf(Logger.mainLoggerConfig.format) : Winston.format.json())

--- a/test/Logger.spec.ts
+++ b/test/Logger.spec.ts
@@ -76,7 +76,7 @@ describe('typescript-loggable', () => {
                 transports: expect.arrayContaining([expect.any(Winston.transports.Console)])
             }));
             expect(mockFormatTimestamp).toBeCalledWith({
-                format: 'YYYY-MM-DD HH:mm:ss'
+                format: 'YYYY-MM-DDTHH:mm:ss.SSSZZ'
             });
             expect(mockFormatCombine).toBeCalledWith('timestamp result', 'ms result', 'json result');
             expect(mockFormatTimestamp).toBeCalledTimes(1);
@@ -104,7 +104,7 @@ describe('typescript-loggable', () => {
                 transports: expect.arrayContaining([expect.any(Winston.transports.Console)])
             }));
             expect(mockFormatTimestamp).toBeCalledWith({
-                format: 'YYYY-MM-DD HH:mm:ss'
+                format: 'YYYY-MM-DDTHH:mm:ss.SSSZZ'
             });
             expect(mockFormatCombine).toBeCalledWith('timestamp result', 'ms result', 'printf result');
             expect(mockFormatTimestamp).toBeCalledTimes(1);


### PR DESCRIPTION
Just added timezone to `timestamp` format and, as a suggestion, changed `timezone` format to match `ISO8601`.